### PR TITLE
Make channel an optional parameter

### DIFF
--- a/RPi/GPIO/definitions/functions/common.py
+++ b/RPi/GPIO/definitions/functions/common.py
@@ -1,4 +1,4 @@
-def cleanup(channel_or_chan_list):
+def cleanup(channel_or_chan_list=None):
     pass
 
 


### PR DESCRIPTION
RPi.GPIO supports calling cleanup() without parameters to cleanup
all GPIOs used in the session. By adding `=None` warnings about
missing parameters are ignored.